### PR TITLE
Fix required & optional params checking.

### DIFF
--- a/lib/zero_push.js
+++ b/lib/zero_push.js
@@ -260,13 +260,13 @@ ZeroPush.prototype.register = function (requiredParams, optionalParams, callback
 
   var self = this;
 
-  if (!requiredParams || typeof requiredParams !== "string" || !util.isArray(requiredParams))
+  if ((!requiredParams || typeof requiredParams !== "string") && !util.isArray(requiredParams))
     return callback(new Error("Undefined required parameter"));
 
   if (typeof optionalParams === "function")
     callback = optionalParams;
 
-  if (optionalParams && typeof optionalParams !== "string" || !util.isArray(optionalParams))
+  if ((!optionalParams || typeof optionalParams !== "string") && !util.isArray(optionalParams))
     return callback(new Error("Undefined optional parameter"));
 
   async.waterfall(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nzero-push",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "ZeroPush is a simple service for sending Apple Push Notifications. This library wraps the API requests for use in NodeJS.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Noticed this on device token registration

It should only throw error if the params are not a string **and** not an array.