### PR TITLE
Fixed typo

### DIFF
--- a/lib/zero_push.js
+++ b/lib/zero_push.js
@@ -50,7 +50,7 @@ ZeroPush.prototype.broadcast = function (channel, notification, callback) {
   if ( typeof callback !== "function" )
     throw new Error("Missing callback function");
 
-  Endpoints.brodcast(channel, notification, callback, this);
+  Endpoints.broadcast(channel, notification, callback, this);
 };
 
 ZeroPush.prototype.unregister = function (deviceTokens, callback) {


### PR DESCRIPTION
Fixed a typo with the 'Endpoints.broadcast' method.